### PR TITLE
Update config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ setTimeout(() => {
 
 // Dispose (stop sox process and listeners) after 30s
 setTimeout(() => {
-  console.log("dispose all listeners and free ressources")
+  console.log("dispose all listeners and free resources")
   clap.dispose()
 }, 30000)
 ```

--- a/README.md
+++ b/README.md
@@ -129,12 +129,13 @@ You can pass a configuration object and override the default values when you cre
 ```bash
 // DEFAULT CONFIG
 var CONFIG = {
-  AUDIO_SOURCE: 'hw:1,0', // this is your microphone input. If you dont know it you can refer to this thread (http://www.voxforge.org/home/docs/faq/faq/linux-how-to-determine-your-audio-cards-or-usb-mics-maximum-sampling-rate)
-  DETECTION_PERCENTAGE_START : '5%', // minimum noise percentage threshold necessary to start recording sound
-  DETECTION_PERCENTAGE_END: '5%',  // minimum noise percentage threshold necessary to stop recording sound
+  AUDIO_SOURCE: 'alsa hw:1,0', // this is your microphone input. If you dont know it you can refer to this thread (http://www.voxforge.org/home/docs/faq/faq/linux-how-to-determine-your-audio-cards-or-usb-mics-maximum-sampling-rate)
+  DETECTION_PERCENTAGE_START : '10%', // minimum noise percentage threshold necessary to start recording sound
+  DETECTION_PERCENTAGE_END: '10%',  // minimum noise percentage threshold necessary to stop recording sound
   CLAP_AMPLITUDE_THRESHOLD: 0.7, // minimum amplitude threshold to be considered as clap
   CLAP_ENERGY_THRESHOLD: 0.3,  // maximum energy threshold to be considered as clap
-  MAX_HISTORY_LENGTH: 10 // all claps are stored in history, this is its max length
+  CLAP_MAX_DURATION: 1500,
+  MAX_HISTORY_LENGTH: 100 // all claps are stored in history, this is its max length
 }
 const clap = new ClapDetector(CONFIG)
 ```


### PR DESCRIPTION
This pull request updates the config in the README to match the code in the config to prevent the following error:
```
/home/pi/node_modules/clap-detector/lib/index.js:177
          throw err;
          ^

Error: Command failed: sox -t hw:1,0 /home/pi/input.wav silence 1 0.0001 5% 1 0.1 5% −−no−show−progress stat
sox FAIL sox: Not enough input filenames specified


    at ChildProcess.exithandler (child_process.js:383:12)
    at ChildProcess.emit (events.js:400:28)
    at maybeClose (internal/child_process.js:1058:16)
    at Socket.<anonymous> (internal/child_process.js:443:11)
    at Socket.emit (events.js:400:28)
    at Pipe.<anonymous> (net.js:686:12) {
  killed: false,
  code: 1,
  signal: null,
  cmd: 'sox -t hw:1,0 /home/pi/input.wav silence 1 0.0001 5% 1 0.1 5% −−no−show−progress stat'
}
```