### PR TITLE
Add plugin to fix default export on Babel 6+

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,5 +8,8 @@
         }
       }
     ]
+  ],
+  "plugins": [
+    "add-module-exports"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@babel/cli": "7.13.10",
     "@babel/core": "7.13.10",
-    "@babel/preset-env": "7.13.10"
+    "@babel/preset-env": "7.13.10",
+    "babel-plugin-add-module-exports": "^1.0.4"
   }
 }


### PR DESCRIPTION
This pull request restores compatibility with the `default` method after transpilation with Babel 6+.

Fixes https://github.com/tom-s/clap-detector/issues/10, https://github.com/tom-s/clap-detector/issues/20.

