### PR TITLE
Fix `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -132,7 +132,7 @@ class ClapDetector {
       const cmd = 'sox -t ' + AUDIO_SOURCE + ' ' + filename + ' silence 1 0.0001 '  + DETECTION_PERCENTAGE_START + ' 1 0.1 ' + DETECTION_PERCENTAGE_END + ' −−no−show−progress stat'
       let body  = ''
 
-      this.child = exec(cmd, (err) => {
+      this.child = exec(cmd, {maxBuffer: 1024 * 1024 * 10}, (err) => {
         if (err) {
           throw err
           return


### PR DESCRIPTION
This pull request attempts to fix the `RangeError [ERR_CHILD_PROCESS_STDIO_MAXBUFFER]: stderr maxBuffer length exceeded`. Alternatively, `exec` could be replaced with `spawn` as suggested in https://github.com/tom-s/clap-detector/issues/21#issuecomment-1024965201 and implemented in https://github.com/131/clap-trigger/blob/b6f890e/index.js#L80-L104, this would require more significant changes though.